### PR TITLE
Make titles longer

### DIFF
--- a/canvas
+++ b/canvas
@@ -405,8 +405,8 @@ case "$subcommand" in
 
                     if [ $(_jqRow '.workflow_state') != "unsubmitted" ]; then
                         title="$(_jqRow '.assignment' | jq -r '.name')"
-                        if [ ${#title} -gt 30 ]; then
-                            title="${title:0:27}..."
+                        if [ ${#title} -gt $WIDTH ]; then
+                            title="${title:0:$WIDTH_INNER}..."
                         fi
                         titlesArray+=( "$title" )
                         coursesArray+=( $( echo "$course_code" | sed 's@^[^0-9]*\([0-9]\+\).*@\1@' ) )

--- a/canvas
+++ b/canvas
@@ -85,6 +85,13 @@ CANVAS_TOKEN=""
 SETTINGS_LOCATION=~/.config/canvas_settings
 CHANGE_ENABLED=false
 
+# Calculate widths
+COLS=$(tput cols)                   # Get width of terminal
+WIDTH=$((COLS - 45))               # date width = 22
+WIDTH=$((WIDTH > 30 ? WIDTH : 30))  # Clamp width to a minimum of 30
+WIDTH_INNER=$((WIDTH - 3))
+
+
 subcommand=$1
 if [ "$subcommand" = "null" ] || [ "$subcommand" = "" ]; then
     subcommand="h"
@@ -232,8 +239,8 @@ case "$subcommand" in
                                 fi
                                 colorsArray+=( "$color" )
                                 title=$(_jqRow '.name')
-                                if [ ${#title} -gt 30 ]; then
-                                    title="${title:0:27}..."
+                                if [ ${#title} -gt $WIDTH ]; then
+                                    title="${title:0:$WIDTH_INNER}..."
                                 fi
                                 titlesArray+=( "$title" )
                                 if [ "$invalidDate" = true ]; then
@@ -284,7 +291,7 @@ case "$subcommand" in
                     printf "\n"
                     lastCourse="${coursesArray[i]}"
                 fi
-                printf "%-${longestCourse}s  ${colorsArray[i]}\e]8;;${linksArray[i]}\a%-${longestTitle}s\e]8;;\a$NC  %-21s" "${coursesArray[i]}" "${titlesArray[i]}" "${deadlinesArray[i]}"
+                printf "%-${longestCourse}s  ${colorsArray[i]}\e]8;;${linksArray[i]}\a%-${WIDTH}s\e]8;;\a$NC  %-${WIDTH}s" "${coursesArray[i]}" "${titlesArray[i]}" "${deadlinesArray[i]}"
                 if [ "$includeLocked" = true ]; then
                     printf "  %-21s" "${unlocksAtArray[i]}"
                 fi


### PR DESCRIPTION
You could make titles longer if you calculate the width of the terminal with `tput`. I'm not saying this is the correct way to do it, I don't think I did the padding right. But I prefer it if I can see the whole title. Using `tput` should be able to make it fit on anything :). 

lmk if you want me to make any changes.